### PR TITLE
Add assertions to verify compiletime & runtime condiitons at various points in code

### DIFF
--- a/src/main/java/kniaz/logic/command/CommandFactory.java
+++ b/src/main/java/kniaz/logic/command/CommandFactory.java
@@ -37,6 +37,14 @@ public abstract class CommandFactory {
                     InstructionType.INVALID, new InvalidHandler()
             ));
 
+    static {
+        // This ensures that at compile time all instruction types have an explicit, valid handler
+        for (InstructionType i : InstructionType.values()) {
+            assert(INSTRUCT_TO_HANDLER.containsKey(i))
+                    : "There was a command " + i.alias + "with no associated handler!";
+        }
+    }
+
     /**
      * Makes a new KniazCommand from the provided instruction and arguments
      * @param instruction the instruction type the command is to have
@@ -47,8 +55,10 @@ public abstract class CommandFactory {
     public static KniazCommand makeCommand(InstructionType instruction,
                                            List<String> unnamedArgs,
                                            Map<? extends String, ? extends String> namedArgs) {
-        CommandHandler handler = INSTRUCT_TO_HANDLER.getOrDefault(instruction, new InvalidHandler());
+        assert INSTRUCT_TO_HANDLER.containsKey(instruction)
+                : "Tried to find a handler for a command that has unknown mapping!";
 
+        CommandHandler handler = INSTRUCT_TO_HANDLER.get(instruction);
         return new KniazCommand(instruction, handler, unnamedArgs, namedArgs);
 
         // Guaranteed at this point command is valid

--- a/src/main/java/kniaz/logic/handler/FindHandler.java
+++ b/src/main/java/kniaz/logic/handler/FindHandler.java
@@ -55,6 +55,8 @@ public class FindHandler implements CommandHandler {
                 // This nesting's not TOO bad
             }
         }
+        assert out instanceof TaskList;
+        // unlikely to occur but in case
 
         return out;
 

--- a/src/main/java/ui/KniazOutputFlavourer.java
+++ b/src/main/java/ui/KniazOutputFlavourer.java
@@ -31,8 +31,16 @@ public class KniazOutputFlavourer {
                     InstructionType.FIND,
                     "I have searched the records. Here are the results :",
                     InstructionType.INVALID,
-                    "I do not recognise this command.[THIS SHOULD NORMALLY NOT BE SEEN]"
+                    "I do not recognise this command."
             ));
+
+    static {
+        // This ensures that at compile time all instruction types have an explicit, valid handler
+        for (InstructionType i : InstructionType.values()) {
+            assert(INSTRUCT_TO_FLAVOURSTRING.containsKey(i))
+                    : "There was a command " + i.alias + "with no associated flavour string!";
+        }
+    }
 
     /**
      * Constructor for the class
@@ -47,8 +55,7 @@ public class KniazOutputFlavourer {
      * @return the flavour string
      */
     public String getFlavourFor(InstructionType instr) {
-        return INSTRUCT_TO_FLAVOURSTRING.getOrDefault(instr,
-                "I do not recognise this command.[THIS SHOULD NOT NORMALLY BE SEEN]");
+        return INSTRUCT_TO_FLAVOURSTRING.get(instr);
     }
 
 }

--- a/src/main/java/ui/inputparser/InstructionType.java
+++ b/src/main/java/ui/inputparser/InstructionType.java
@@ -33,11 +33,12 @@ public enum InstructionType {
         this.numUnnamedArgs = numUnnamedArgs;
         this.numNamedArgs = namedArgs;
         this.argNames = argNames;
-        if (this.numNamedArgs != argNames.length) {
-            throw new ExceptionInInitializerError(String.format(
-                    "InstructionType should have %s named args specified, "
-                            + "but only has %s!", namedArgs, argNames.length));
-        }
+
+
+        assert this.numNamedArgs == argNames.length
+                : String.format(
+                        "InstructionType should have %s named args specified, but only has %s!",
+                namedArgs, argNames.length);
     }
 
     /**


### PR DESCRIPTION
Currently, no such assertions. These will help verify & document key assumptions should hold in certain areas, e.g. that every InstructionType has a mapping to both some kind of reply, and some type of handler.

